### PR TITLE
Support turn server and certdumper on arm64.

### DIFF
--- a/roles/docker_container/tasks/main.yml
+++ b/roles/docker_container/tasks/main.yml
@@ -50,7 +50,7 @@
   include_tasks: turnserver.yml
   when: 
     - talk_install|bool
-    - ansible_architecture == 'x86_64'
+    - (ansible_architecture == 'x86_64' or ansible_architecture == 'aarch64')
 
 - name: docker network
   include_tasks: network.yml

--- a/roles/docker_container/tasks/traefik.yml
+++ b/roles/docker_container/tasks/traefik.yml
@@ -61,7 +61,7 @@
 - name: "{{ 'Create' if (state is undefined or 'absent' not in state) else 'Terminate' }} the traefik cert dumper container"
   docker_container:
     name: certdumper
-    image: svendowideit/traefik-certdumper:latest
+    image: "{{ 'serverror' if ansible_architecture == 'aarch64' else 'svendowideit' }}/traefik-certdumper:latest"
     restart_policy: unless-stopped
     volumes:
       - '{{ traefik_config_dir }}:/traefik'
@@ -69,4 +69,4 @@
     labels:
       traefik.enable:                        "false"
       com.centurylinklabs.watchtower.enable: "true"
-  when: ansible_architecture == 'x86_64'
+  when: (ansible_architecture == 'x86_64' or ansible_architecture == 'aarch64')

--- a/roles/docker_container/tasks/turnserver.yml
+++ b/roles/docker_container/tasks/turnserver.yml
@@ -4,7 +4,7 @@
 - name: "{{ 'Create' if (state is undefined or 'absent' not in state) else 'Terminate' }} the turnserver container"
   docker_container:
     name:           'turn_server'
-    image:          'instrumentisto/coturn:{{ docker_turnserver_image | default("latest") }}'
+    image:          "{{ 'serverror' if ansible_architecture == 'aarch64' else 'instrumentisto' }}/coturn:{{ docker_turnserver_image | default('latest') }}"
     restart_policy: 'unless-stopped'
     command: >
       -n

--- a/roles/docker_container/tasks/watchtower.yml
+++ b/roles/docker_container/tasks/watchtower.yml
@@ -5,7 +5,7 @@
   docker_container:
     name: watchtower
     image: containrrr/watchtower:{{ docker_watchtower_image | default('latest') }}
-    command: --cleanup --schedule "0 0 0 * * *"
+    command: --cleanup --schedule "0 0 0 * * *" --label-enable
     restart_policy: always
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock

--- a/roles/nextcloud_config/tasks/main.yml
+++ b/roles/nextcloud_config/tasks/main.yml
@@ -93,4 +93,4 @@
   include_tasks: talk.yml
   when: 
     - talk_install|bool
-    - ansible_architecture == 'x86_64'
+    - (ansible_architecture == 'x86_64' or ansible_architecture == 'aarch64')

--- a/roles/prep_os/tasks/tuning.yml
+++ b/roles/prep_os/tasks/tuning.yml
@@ -24,9 +24,11 @@
     owner: root
     group: root
     mode: 0644
+  when: ansible_architecture == 'x86_64'
 
 - name: enable service disable-transparent-hugepages
   service:
     name: disable-transparent-huge-pages.service
     enabled: true
     state: started
+  when: ansible_architecture == 'x86_64'


### PR DESCRIPTION
Disable transparent huge page service for arm/64.
Set watchtower to only watch labelled containers.
fixes ReinerNippes/nextcloud_on_docker#45