### PR TITLE
Fixed LetEncrypted A+ SSL Labs

### DIFF
--- a/inventory
+++ b/inventory
@@ -77,5 +77,5 @@ adminer_enabled             = false
 
 
 # Set to true to install Portainer webgui for Docker.
-portainer_enabled           = true
+portainer_enabled           = false
 portainer_passwd            = ''       # If empty the playbook will generate a random password.

--- a/roles/docker_container/templates/dynamic.yaml.j2
+++ b/roles/docker_container/templates/dynamic.yaml.j2
@@ -2,7 +2,7 @@
 
 tls:
   options:
-    OptionsDefault:
+    default:
       minVersion: 'VersionTLS12'
       maxVersion: 'VersionTLS13'
       cipherSuites:
@@ -10,5 +10,3 @@ tls:
       - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
       - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
       - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-      - TLS_RSA_WITH_AES_256_GCM_SHA384
-      - TLS_RSA_WITH_AES_128_GCM_SHA256

--- a/roles/docker_container/templates/traefik.yaml.j2
+++ b/roles/docker_container/templates/traefik.yaml.j2
@@ -16,8 +16,8 @@ providers:
 log:
   level: error
 {% if ssl_cert_email is defined %}
-certificatesResolver:
-  certificatesResolverDefault:
+certificatesResolvers:
+  default:
     acme:
       email: "{{ ssl_cert_email }}"
       storage: 'acme.json'


### PR DESCRIPTION
Fixed the errors for Let Encrypted. SSL Labs reports A+ with current settings. Have to use only ECDSA only certs, otherwise you will get a forward secrecy problem which lowers the grade to B.